### PR TITLE
Patching now respects failed test ops

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = exports = function checkPermissions(schema, options) {
 	PATCH LOGIC
 	===========
 	*/
-	
+
 	//Find all attributes that have writable set to false
 	var schemaWriteBlacklist = _.filter(Object.keys(schema.paths), function(pathName) {
 		var path = schema.path(pathName);
@@ -56,6 +56,15 @@ module.exports = exports = function checkPermissions(schema, options) {
 
 		//Apply the patch
 		try {
+			for (var len = patches.length, i=0; i<len; ++i) {
+				var patch = patches[i];
+				if(patch.op=='test'){
+					var success = jsonpatch.apply(item, [].concat(patch), true);
+					if(!success){
+						return callback(new Error('The json-patch test op at index [' + i + '] has failed. No changes have been applied to the document'));
+					}
+				}
+			}
 			jsonpatch.apply(this, patches, true);
 		} catch(err) {
 			return callback(err);
@@ -74,7 +83,7 @@ module.exports = exports = function checkPermissions(schema, options) {
 		return '/' + path.split('.').join('/');
 	}
 
-	
+
 
 	/*
 	========================
@@ -92,7 +101,7 @@ module.exports = exports = function checkPermissions(schema, options) {
 	});
 
 	this.readBlacklist = _.union(globalReadBlacklist, schemaReadBlacklist);
-	
+
 	/*
 	 * Takes this object and removes any properties that are marked as {readable: false} in the schema.
 	 * Supplying any additional keys as arguments will remove them.
@@ -121,5 +130,5 @@ module.exports = exports = function checkPermissions(schema, options) {
 		}
 		return collection;
 	}
-	
+
 };

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports = exports = function checkPermissions(schema, options) {
 			for (var len = patches.length, i=0; i<len; ++i) {
 				var patch = patches[i];
 				if(patch.op=='test'){
-					var success = jsonpatch.apply(item, [].concat(patch), true);
+					var success = jsonpatch.apply(this, [].concat(patch), true);
 					if(!success){
 						return callback(new Error('The json-patch test op at index [' + i + '] has failed. No changes have been applied to the document'));
 					}


### PR DESCRIPTION
The new code first run all the test ops in the patch sequence before attempting to apply any changes. If any test op fails then no changes are applied to the document. Hopefully you will be able to remove this when fast-json-patch finally gets fixed.